### PR TITLE
Make margin-bottom of unordered and ordered lists 0

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -2,44 +2,7 @@
 
 Welcome to TheMoeWay Resources Sheet, resources are categorised into "Learning" Japanese and "Acquiring" Japanese.   
 
-Resource descriptions will be added soon, for now, just links.  
-
-<h1>Table of Contents</h1>
-
-<!-- TOC -->
-
-<h2>Learning Japanese</h2>
-
-  - [Kana](#kana)
-  - [Kanji](#kanji)
-  - [Vocabulary](#vocabulary)
-  - [Grammar](#grammar)
-  
-<h2>Acquiring Japanese</h2>
-
- - [Anime](#anime)
- - [J-Drama & TV Shows](#j-drama-tv-shows)
- - [Manga](#manga)
- - [Light Novels and Literary Texts](#light-novels-and-literary-texts)
- - [Visual Novels & Games](visual-novels-games)
- - [Audiobooks](#audiobooks)
- - [Subtitles](#subtitles)
- - [Sentence Search](#sentence-search)
- - [Dictionaries](#dictionaries)
- - [Applications (Desktop)](#applications-desktop)
- - [Applications (Mobille)](#applications-mobile)
- - [Browser Extensions](#browser-extensions)
- - [Downloading Tools](#downloading-tools)
- - [Private Trackers](#private-trackers)
- - [Other Software](#other-software)
- - [VPNs (Japan location specific)](#vpn-japan-location-specific)
- - [Condensed Audio](#condensed-audio)
- - [Mining](#mining)
- - [Guides/Methods/Motivation](#guides-methods-motivation)
- - ["Other"](#other)
- 
-<!-- /TOC -->
-
+Resource descriptions will be added soon, for now, just links.
 ## Learning Japanese 
 
 ### Kana

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,3 @@
+.md-typeset ul li, .md-typeset ol {
+    margin-bottom: 0em;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,3 @@
-.md-typeset ul li, .md-typeset ol {
+.md-typeset ul li, .md-typeset ol li{
     margin-bottom: 0em;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,6 @@ nav:
     - 'Resources': 'resources.md'
   - 'About':
     - 'Contact & Support': 'contact.md'
-
 theme:
   features:
     - navigation.instant
@@ -43,3 +42,5 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.mark
   - pymdownx.tilde
+extra_css:
+  - stylesheets/extra.css


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/2382537/106374415-46148380-6338-11eb-975b-00ade16ca69b.png)

After:
![image](https://user-images.githubusercontent.com/2382537/106374423-4f055500-6338-11eb-92d7-573dd31cf4c1.png)


Changes for numbered lists too:
Before: 
![image](https://user-images.githubusercontent.com/2382537/106374426-5e849e00-6338-11eb-8c54-6dec269a8473.png)

After: 
![image](https://user-images.githubusercontent.com/2382537/106374429-67756f80-6338-11eb-9b50-5da1f64c5dcf.png)

I'm tempted to do this change only for unordered lists
