### PR TITLE
Enable searching for Japanese text

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,3 +48,8 @@ markdown_extensions:
   - pymdownx.superfences
 extra_css:
   - stylesheets/extra.css
+plugins:
+  - search:
+      lang:
+        - en
+        - ja


### PR DESCRIPTION
Small thing that was bothering me. You can test it out here if you want https://soameshi.github.io/shoui520.github.io/ (images are a bit messed up but I think that's because I'm not hosting the site on learnjapanese.moe? not super sure, but that shouldn't matter post-merge)

