### PR TITLE
Kaishi references + setup site change

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,10 +6,7 @@ Due to the FAQ becoming ridiculously long, it can be hard to quickly find what y
 
 ### Why this FAQ was made
 
-This FAQ aims to assist you with your self study. When it comes to learning Japanese, it is almost inevitable that you will often wonder about a lot of things. I’m not going to always be here to help you out, so I might as well dump all my knowledge here. I am sure your question will be answered in this FAQ. If not, I'm willing to answer any question you have if you sub to my Patreon.  
-
-### Tango vs Core2.3k
-Why does TheMoeWay recommend the Tango deck in the main guide but Core2.3k in UsagiSpoon? The reason is not so simple, but the main guide and UsagiSpoon have different aims in mind. On the one hand, the main guide provides general guidelines on how to learn Japanese, but UsagiSpoon assumes you will follow everything written step by step. Why is this important? Well before I get into that, I would like to go through the main benefits and drawbacks of Tango vs Core2.3k. The cards in Tango are sentence cards, which means they show you full sentences for you to read and get the meaning from. The cards also re-use words already introduced before. This means that Tango is relatively easy. However, this also means Tango is less efficient, as not every new card is necessarily a new piece of information. On the other hand, in the Core2.3k deck, every other card is a new word. The information on the front of the card is the word on its own in kanji. This means that Core2.3k is more efficient, as every single new card is a new piece of information. However, this also makes Core2.3k very difficult. Now that that's out the way, the difference in recommendation is down to the purpose of the guide. UsagiSpoon was written with the intention of making a Japanese guide focused on efficiency. The use of early immersion, condensed audio, kanji cards, grammar study, vocab study, all in just 30 days also shows how UsagiSpoon tries to be efficient. I have received a lot of feedback on UsagiSpoon however, pointing out the difficulty of Core2.3k. I have also received feedback for the guide regarding the Tango decks, saying there are too many useless cards. Neither deck is perfect, whether you are following UsagiSpoon, or just following the main guide, feel free to use any vocab/sentence deck that you wish.
+This FAQ aims to assist you with your self study. When it comes to learning Japanese, it is almost inevitable that you will often wonder about a lot of things. I’m not going to always be here to help you out, so I might as well dump all my knowledge here. I am sure your question will be answered in this FAQ. If not, I'm willing to answer any question you have if you sub to my Patreon.
 ### How do I learn Japanese?
 Through massive amounts of *input*, in other words **immersion.** See [the guide](/guide) for more info.
 ### Can you teach me Japanese?
@@ -23,7 +20,7 @@ Raw anime, untranslated manga, light novels and visual novels. Unsubbed J-drama,
 ### Hey shoui, so I know the method you describe is better than what I’m doing right now but can you please give me permission to carry on doing my own method?
 Don’t care. It’s your Japanese, not mine. 
 ### When should I start using Anki?
-You can start to use Anki whenever you want actually, you can even learn the kana with it. However I recommend you start using Anki when you already have a grasp of the kana and basic grammar, after that you can download and start working on the Tango Anki decks. (Mining comes after)
+You can start to use Anki whenever you want actually, you can even learn the kana with it. However I recommend you start using Anki when you already have a grasp of the kana and basic grammar, after that you can download and start working on the Kaishi 1.5k Anki deck. (Mining comes after)
 ### When (what time of day) should I do Anki?
 I recommend doing Anki the first thing in the morning. (As early as possible)
 ### How long should I spend on Anki?
@@ -102,13 +99,8 @@ Learning is simple as it is. Don’t fall for pretty-UI learning programs such a
 Animebook. UPDATE: You can use [MPV](https://youtu.be/bbg6ztWecbU) instead
 ### How many words do I need to know to understand EVERYTHING?
 Around 30k. You may think, but uh with 2k I can understand 80%? Yeah but it gets very steep after that. 10k is around 98%, 20k is around 99% and 30k is like 99.9% because I can’t guarantee that you can understand 100% with 30k. But it is definitely a good number to aim for. I don't understand everything in English so is it really worth the endeavour? That is your decision.
-### Why are Core decks bad? Should I do Core decks?
-They aren't bad... it's just...
-The frequency lists the Core decks are based on are very low quality. So you aren’t even learning “core” words. It is also much more difficult than Tango.
 ### HUH? NO FURIGANA? THAT’S IMPOSSIBLE TO READ THEN!!!
 Furigana has never been necessary and relying on it only holds you back becoming able to read fluently. You should learn how to function without it. In my opinion furigana is pretty useless apart from when it's on names.
-### What’s better Tango N5+N4 or Core2k/3k?
-Doesn’t matter as long as you get onto mining straight after you completed them. :slight_smile:
 ### I don’t have that green + button like you do in Yomichan
 Setup AnkiConnect. <https://foosoft.net/projects/anki-connect/>
 Make sure you also have a proper card type and have filled in the fields correctly.
@@ -225,7 +217,7 @@ If you have money you can buy visual novels from Steam. If you are lucky enough 
 [vn guide](/vn)
 ### How do I switch from traditional methods to your method?
 You probably have a stupid flashcard deck on some SRS that probably isn’t Anki. Even if you used Anki you were probably using some stupid pre-made deck. You are halfway through your second Genki textbook or whatever. You paid for Memrise Premium. You have a WaniKani subscription. LingoDeer lured you into buying their premium too. What should you do? Screw them. Cancel your premium subscriptions. Learning Japanese is completely FREE and I can guarantee you that. Delete your old stupid decks. You may worry that you may forget everything you’ve learned, but you won’t. You won’t forget everything. Stop using the textbook, return it or something. You may also have HelloTalk friends. Well let me tell you the truth about HelloTalk friends: they don't even care about you. They just want to practice English with you, not Japanese. If you ask them to correct you they will probably block you, so they’re just stopping any chance of you ever improving. So forget about them, why even bother? Speaking practice doesn't really mean much without immersion anyway.
-Now, it may be different what you gotta do depending on how good you are. If you haven’t gotten that far (e.g. can’t understand like 50% of anime yet) then just follow the [Japanese Guide](/guide) from the beginning, if you already know kana, you don’t need to re-learn them. Watch the Cure Dolly grammar guide. Setup Anki, import the Tango N4+N5/Core3k decks and work through them. Immerse everyday. 
+Now, it may be different what you gotta do depending on how good you are. If you haven’t gotten that far (e.g. can’t understand like 50% of anime yet) then just follow the [Japanese Guide](/guide) from the beginning, if you already know kana, you don’t need to re-learn them. Watch the Cure Dolly grammar guide. Setup Anki, import the Kaishi 1.5k deck and work through it. Immerse everyday. 
 If you’re a so-called “intermediate” then just get to mining with AnimeCards straight away. Immerse everyday. 
 There is no way you got to an “advanced” level or even close using a bad method so I’ll end this here.
 ### How to deal with words with multiple meanings?
@@ -270,11 +262,6 @@ You’re probably confused but trust me it is tricky at the beginning but overti
 If you’re doing sentence cards then I’ll talk you through the review process.
 Let's think back to bilingual cards, how do you grade them? You should already know that the sentence that goes on the front is the thing you need to understand, and the on the back is the word along with its reading and definition is needed to understand the sentence. 
 The process of reviewing sentence cards goes as follows: You read the sentence, reveal the backside of the card, read the definition that is on the back of the card, if the definition on the back made you understand the sentence better, then grade it as a Fail. If not, grade it as a Pass. In other words, you grade the card as a Pass if the extra information (the definition) on the card was not needed to comprehend the sentence. It’s basically the same for monolingual cards.
-### How to grade Tango cards?
-You should already know that the sentence that goes on the front is the thing you need to understand, and the on the back is the word along with its reading and definition is needed to understand the sentence. 
-The process of reviewing sentence cards goes as follows: You read the sentence, reveal the backside of the card, read the definition that is on the back of the card, if the definition on the back made you understand the sentence better, then grade it as a Fail. If not, grade it as a Pass. In other words, you grade the card as a Pass if the extra information (the definition) on the card was not needed to comprehend the sentence.
-### Why do you do AnimeCards over sentence cards?
-Muh opinion
 ### I want to pass the JLPT N1. How long will that take me with your method?
 Cant say as it all depends on how much you immerse  
 Also make sure you study the grammar used in JLPT N1 (it is easy to look over them in immersion)  
@@ -298,7 +285,7 @@ Yeah.
 No.
 ### The Intermediate Blues
 (Intermediate= >N1)
-The Intermediate Blues. The Intermediate Plateau. Whatever you want to call it. This is the feeling of not feeling like you are improving, despite doing 40 Anki cards per day, speeding through your reviews, reading for 3 hours, listening for 6 hours. In fact, there is no plateau. It doesn’t exist. You are either improving (when u immerse) or getting worse (when u dont immerse). The Intermediate Blues are usually felt when you remember back when you were a beginner and you could feel your progress everyday, you don’t really get that same feeling as an intermediate learner. 
+The Intermediate Blues. The Intermediate Plateau. Whatever you want to call it. This is the feeling of not feeling like you are improving, despite doing 40 Anki cards per day, speeding through your reviews, reading for 3 hours, listening for 6 hours. In fact, there is no plateau. It doesn’t exist. You are either improving (when you immerse) or getting worse (when you dont immerse). The Intermediate Blues are usually felt when you remember back when you were a beginner and you could feel your progress everyday, you don’t really get that same feeling as an intermediate learner. 
 You are improving.
 Please note that you can understand like 80% of your immersion with like 2000 words. You can understand like 90% with 10,000. It just gets very steep. 20,000 you understand like 95%. 30,000 you may finally be close to the 100%. The feeling sucks, but you gotta keep going.
 What usually motivates is when I hear in an anime a word I learned the day before, it always gives me a motivation boost no matter what :wink:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -135,18 +135,9 @@ The bulk of your language learning journey is learning vocabulary, so you will b
 
 Anki is a spaced repetition system (SRS) flashcard program. It is designed to help you remember information. You can get it [here](https://apps.ankiweb.net/)  
 
-![Anki](img/anki21_tango_example.jpg)  
+![Anki](https://github.com/donkuri/Kaishi/raw/main/pics/back-card.png)
 
-You should use Anki to build up a vocabulary of basic words to assist your immersion, after that learning vocabulary from immersion, especially in reading, becomes easier. Usually people use the *Core 2K* deck to build up a vocabulary of 2000 words. It works by showing you the word you need to learn at the front, and it has the meaning and how to read it at the back, along with a voiced example sentence. You learn words with Core2K by recalling the meaning and reading of the displayed word. However, I advise against using Core 2K, and suggest you do [*Tango N5+N4*](https://learnjapanese.moe/resources/#vocabulary) instead, and here’s why:
-
-Core 2K is significantly harder than [Tango N5+N4](https://learnjapanese.moe/resources/#vocabulary) because Tango has the sentence on the front, Core 2K has only the word on the front.  
-Tango decks work by showing you a sentence at the front, and the piece of information (a meaning and reading) needed to understand the sentence at the back. You click "Good" whenever you understood the sentence, and "Again" when you did not.  
-The "N" number in the deck name refers to the Japanese Language Proficiency Test (JLPT), with N5 being the lowest, easiest and N1 being the highest.  
-Sentences make recalling vocabulary easier, after all, it is much more close to how we use language in real life as opposed to isolated words.  
-
-**However, it is important to note that Tango's translations are not literal, and do not represent Japanese structure well, so I guess that's a flaw of Tango. In other cases, it might be utterly wrong.**  
-
-People have always struggled with Core 2K, and to make the process smoother, I recommend [Tango N5+N4](https://learnjapanese.moe/resources/#vocabulary) over Core 2K. Especially if you don’t want to do isolated kanji study!  
+You should use Anki to build up a vocabulary of basic words to assist your immersion, after that learning vocabulary from immersion, especially in reading, becomes easier. To learn vocabulary, I recommend using the new beginner deck [Kaishi 1.5k](https://github.com/donkuri/Kaishi/). You will learn 1500 words that are among the most common in the language and are very useful to start reading. You can either get it on GitHub [here](https://github.com/donkuri/Kaishi/releases) (choose the latest release) or on Ankiweb [here](https://ankiweb.net/shared/info/1196762551). The deck works like this: You get a word and a sentence with the word appearing in it being bolded. You can pass the card if you remember the reading and the meaning _of the word_. It's okay if you don't understand the sentence fully, grade yourself on the word. Comprehension will come with time and as you learn more grammar.
 
 I recommend you start learning vocabulary using Anki after you have learned the kana and know extremely basic grammar. How basic is extremely basic is up to you to decide. I will go through how to study grammar after this section, so don't panic.  
 
@@ -167,19 +158,17 @@ With that said, I suggest doing grammar study in conjunction with your immersion
 
 ### Mining  
 
-Mining means when you add vocabulary (often along with the sentence they were found in) into your Anki deck. You can then review these flashcards overtime to make sure you don’t forget them. It usually recommended you begin mining right after you finished Tango N5+N4. You should not bother with Tango N3, N2 and/or N1 because at this point you should be making your own flashcards from your immersion, which is overall a fun process.
+Mining means when you add vocabulary (often along with the sentence they were found in) into your Anki deck. You can then review these flashcards overtime to make sure you don’t forget them. It usually recommended you begin mining right after you finish Kaishi 1.5k. You should not bother with other premade decks at this point you should be making your own flashcards from your immersion, which is overall a fun process.
 
 Mining is something you will be doing for a long time, so this is pretty important.  
 There’s a lot of disagreement when it comes to “formats” of mining, but I think the "Anime cards" format is very good, and has served me really well.   
 
 **Animecards Vocab Cards**  
-Animecards are *High Quality* vocab cards which are different to standard vocab cards. Standard vocab cards simply have the word in kanji form on the front, and the reading and meaning of that word at the back. High quality vocab cards, as opposed to standard vocab cards, have the audio of the sentence (from an anime or voiced Visual Novel), also a picture (from an anime or Visual Novel) and the sentence it came from at the back, making them much more superior to standard vocab cards. 
-
-I think it is good to graduate *sentence* cards after you finish Tango N5 and N4 (Tango decks are sentence cards by the way), as vocabulary cards become easy and quick as you have familiarzied yourself with simple Japanese.  
+Animecards are *High Quality* vocab cards which are different to standard vocab cards. Standard vocab cards simply have the word in kanji form on the front, and the reading and meaning of that word at the back. High quality vocab cards, as opposed to standard vocab cards, have the audio of the sentence (from an anime or voiced Visual Novel), also a picture (from an anime or Visual Novel) and the sentence it came from at the back, making them much more superior to standard vocab cards.
 
 ![Anime Cards](img/cardexample1.jpg)  
 
-※ They are known as “Anime Cards” because of [AnimeCards Site](https://animecards.site)  
+※ They are known as “Anime Cards” because of the [AnimeCards site](https://animecards.site)  
 
 __Benefits__   
 + Easy to set up    
@@ -187,7 +176,7 @@ __Benefits__
 + Able to mine everything and anything (does not follow i+1)    
 + Compensates for words with multiple meanings with the hint field.  
 
-After you have finished the Tango N5 and N4 decks, you should read this site [AnimeCards Site](https://animecards.site/ankisetup/) to learn how to set up a mining deck.   
+After you have finished the Kaishi 1.5k deck, you should read [this site](https://donkuri.github.io/learn-japanese/setup/) to learn how to set up a mining deck.
 
 ### How to Immerse (inputting)  
 What you need to do when immersing is different depending on what stage you are on. This is why making a one size fits all Japanese guide is difficult. I will only go through what you need to do as a beginner.    
@@ -202,7 +191,7 @@ Furthermore, listening just flows without stopping, so you feel more comfortable
 
 Surprisingly, there are many i+1 opportunities in listening immersion as a beginner, especially when you are studying grammar and vocabulary alongside your immersion, so it still passes as comprehensible input, even if you don’t understand other parts. But language is not acquired through incomprehensible input remember? That is true, however, you are still benefiting from incomprehensible input but in a different way; it is improving your ability to distinguish phonemes, in other words giving you a better accent. Immersing even if you don’t understand much is also a great way to build up a habit of interacting with your Japanese.  
 
-With that said though, immersion (input) at this stage will still be largely incomprehensible, however you can change that by working through the Tango Anki decks.    
+With that said though, immersion (input) at this stage will still be largely incomprehensible, however you can change that by working through the Kaishi 1.5k Anki deck.    
 
 Please note that you need to pay attention to your immersion. (Active Immersion).    
 Just putting it on in the background and not paying attention (Passive Immersion) is not going to help you.    
@@ -228,19 +217,19 @@ In our [Resources](/resources) you can find links to sites that let you read a l
 
 **Finding the balance between listening and reading**    
 
-Balance is important. It may be obvious just to split your time up in half, and if you are able to do that, then that is great. However, not  everyone has the time, and when it comes to reading, depending on your current level, it may be considerably difficult to read for extended hours.  For example people that have gotten further in the Tango Anki deck may be able to read longer than those who are a little behind.   
+Balance is important. It may be obvious just to split your time up in half, and if you are able to do that, then that is great. However, not  everyone has the time, and when it comes to reading, depending on your current level, it may be considerably difficult to read for extended hours.  For example people that have gotten further in the Kaishi 1.5k Anki deck may be able to read longer than those who are a little behind.   
  
 So what is the perfect balance?   
-I cannot answer that, that is up to you to experiment and decide. It all depends on your schedule and current level. You don’t need to do reading from day 1, give it a few weeks until you can read basic words from the [Tango N5](https://learnjapanese.moe/resources/#vocabulary) Anki deck.    
+I cannot answer that, that is up to you to experiment and decide. It all depends on your schedule and current level. You don’t need to do reading from day 1, give it a few weeks until you can read basic words from the [Kaishi 1.5k](https://github.com/donkuri/Kaishi/) Anki deck.    
   
 ## Summary  
 
 1. Learn the [kana](#kana) and start learning from your chosen grammar guide.  
-2. Download and setup Anki. Import the Tango N5 deck by clicking on it.  
+2. Download and setup Anki. Import the Kaishi 1.5k deck by clicking on it.  
 3. Click the cog icon next to the deck > Options. The default limit of new cards per day is set at 20. Try to stick with this number for a few days and see how it goes for you, if you feel like it is too much, then you can lower the limit to 15 or even 10. Check in the “Reviews” tab, set the Maximum reviews/day to 9999. Don’t be startled by this number. It will likely not go over 150 with okay retention rate. If you fail to keep up with the reviews you are getting, lower your new cards/day instead of lowering the maximum reviews. This is because not doing your due reviews interferes with Anki’s spaced repetition system. Anki requires consistency in the long term for it to be effective, try creating a schedule for it. Personally I do my Anki when I wake up in the morning.  
 4. Do Anki daily, while also doing your chosen grammar guide **and** immersing daily.  
-5. Repeat until you have finished Tango N5, now you should do Tango N4. You should feel more comfortable with reading now, I suggest you start reading easy manga or watch anime with Japanese subtitles.  
-6. After you've finished Tango N4, set up your mining deck, watch whatever you like, read whatever you like and **HAVE FUN!!**  
+5. Repeat until you have finished Kaishi 1.5k. You should feel more comfortable with reading now, I suggest you start reading easy manga or watch anime with Japanese subtitles.  
+6. After you've finished Kaishi 1.5k, set up your mining deck, watch whatever you like, read whatever you like and **HAVE FUN!!**  
 
 ### Final Notes  
 That’s it. You can get fluent in Japanese just like that. But don’t forget that the most important part is immersion, Anki and grammar only assist your immersion.   

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -4,7 +4,7 @@ Reading Japanese is ***CRUCIAL***. It is important you learn how to read Japanes
 
 With that said, it may seem difficult to learn how to read, after all there are like so much unique kanji on the page! Well yes, reading for the first time will always be painful, you just have to get through it and over time you will become more confident and better at reading. And if anyone is curious on how on earth you're supposed to find out how to read Japanese words and what they mean, just read on, there are certain tools that let you do this easily.  
 
-Before you start reading for real, it is important you have already worked through a pre-made Anki deck, such as Tango N5+N4 *or* Core3k and also a grammar guide such as Tae Kim or Cure Dolly, this is to make the process less painful as there will be more words you know. Second, I recommend also having prior listening immersion experience because 1. it prevents you from developing a bad accent and 2. it helps you parse sentences better when reading.   
+Before you start reading for real, it is important you have already worked through a pre-made Anki deck, such as Kaishi 1.5k and also a grammar guide such as Tae Kim or Cure Dolly, this is to make the process less painful as there will be more words you know. Second, I recommend also having prior listening immersion experience because 1. it prevents you from developing a bad accent and 2. it helps you parse sentences better when reading.   
 
 ### Key Points  
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -23,14 +23,10 @@ Welcome to TheMoeWay Resources Sheet, resources are categorised into "Learning J
 
 
 ### Vocabulary
-- [TheMoeWay Tango N5 Deck](https://drive.google.com/file/d/1pMlJvSrKQOSaiN8sPLdNDvWP31EClxDO/view?usp=sharing) - The first starter Anki deck you should use when starting out.  
-- [TheMoeWay Tango N4 Deck](https://drive.google.com/file/d/1WX9AAKJgiTKN-SySPzuGG8T4nXVhWaSi/view?usp=sharing) - The second starter Anki deck you use after N5.  
-
-!!! info "Tango Decks"
-	You are advised to do Tango over "Core" decks because Tango is easier, as it uses the sentence card format.      
-	However you may want to create a "mining deck" when you complete Tango N4.   
-  
-- [Core2.3K VN Order Deck](https://anacreondjt.gitlab.io/docs/coredeck/) - the Core deck but ordered in terms of visual novel frequency. Not recommended for beginners. You may want to use this if you have studied Japanese before and are deciding on changing your method.   
+- [Kaishi 1.5k](https://ankiweb.net/shared/info/1196762551) - The basic vocabulary deck the guide suggests to learn Japanese. You can also find it [here](https://github.com/donkuri/Kaishi/releases) (click on the `.apkg` file).
+- [TheMoeWay Tango N5 Deck](https://drive.google.com/file/d/1pMlJvSrKQOSaiN8sPLdNDvWP31EClxDO/view?usp=sharing) - An older deck that was recommended before Kaishi 1.5k was made.  
+- [TheMoeWay Tango N4 Deck](https://drive.google.com/file/d/1WX9AAKJgiTKN-SySPzuGG8T4nXVhWaSi/view?usp=sharing) - The follow-up deck to Tango N5 above, now superseded by Kaishi 1.5k.
+- [Core2.3K VN Order Deck](https://anacreondjt.gitlab.io/docs/coredeck/) - The optimized Core deck but ordered in terms of visual novel frequency. Got absorbed into Kaishi 1.5k.
 
 ### Grammar
 - **[※ - Cure Dolly’s Organic Japanese](https://www.youtube.com/playlist?list=PLg9uYxuZf8x_A-vcqqyOFZu06WlhnypWj)** - Cure Dolly is a new grammar guide that has sparked recent attention because of its unique way of teaching Japanese grammar. It aims to teach Japanese grammar in a way that sticks true to the roots of the language, in contrast to other grammar guides that take shortcuts that could cause confusion later on. For that reason, I recommend you start with this. Because of Cure Dolly's speech, and the audio quality presented in the videos, you may find it difficult to understand. However there are subtitles available for all videos that may alleviate this issue, which I recommend you turn on. 

--- a/docs/routine.md
+++ b/docs/routine.md
@@ -259,7 +259,7 @@ Now let's download Anki.
 
 You can download Anki by visiting the official website ([here](https://apps.ankiweb.net/)) and clicking on the Download button. It should scroll the page down to the downloads section. Click the first option.  
 
-Download the required deck [here](https://anacreondjt.gitlab.io/docs/coredeck/)  
+Download the required deck [here](https://github.com/donkuri/Kaishi/releases) (grab the latest `.apkg` file)  
 
 When you first open Anki, the first thing you'll see is the "interface language selector". This just decides what language Anki will be displayed in. Any language is fine.  
 
@@ -289,7 +289,7 @@ The blue number is how many new cards you will be doing in a day.
 
 You might want to lower the number of cards if you find it too hard to keep up with reviews. But don't worry about it right now.   
 
-Click the cog icon next to the *Core2.3k Version 3* deck.  
+Click the cog icon next to the *Kaishi 1.5k* deck.  
 
 Click *Options*.  
 
@@ -321,7 +321,7 @@ Paste this code into the box: `1046608507` and click **OK**.
 
 You need to restart Anki. Close Anki, and launch it back up.  
 
-Click the cog icon next to the *Core2.3k Version 3* deck.  
+Click the cog icon next to the *Kaishi 1.5k* deck.  
 
 Hold the ++shift++ key and click *Options*.  
 
@@ -464,16 +464,6 @@ The next day you can expect to see some cards in the green (Review) pile.
 You will also have a fresh batch of 20 new cards!  
 
 Please make sure you do Anki every day!   
-
-**Q: Why does UsagiSpoon recommend Core instead of Tango?**  
-
-A: Short answer: You learn more with Core.  
-
-Core teaches a new word with each card. The order of words is optimized for anime and visual novels because it teaches the most common words from them. Tango on the other hand, has tons of cards that do not introduce new words, and repeats a lot of similar sentences. ← IMO this is just inefficient. Tango also has weird English translations and stuff. 
-
-While I was writing this day of UsagiSpoon I originally wrote the entire thing showing you how to use the Tango deck. But I had to point out "Hey don't look at the translations!", and "There are a lot of words you will probably never see in anime..." etc, etc. So in the end I saw how the Core deck was better and decided to use that.  
-
-While Core is significantly more difficult (obviously! It is actually introducing something new with every single card) but it will benefit you more than using Tango.  
 
 **Q: Should I worry if I forget a lot?**  
 
@@ -905,7 +895,7 @@ When you click Study now, the first cards will be explanation cards.
 
 After you read them, and understood the usage of the deck, I recommend suspending them.  
 
-You will be working on this deck alongside the Core deck.  
+You will be working on this deck alongside the Kaishi 1.5k deck.  
 
 This deck will NOT help you read kanji.  
 This deck will NOT help you write kanji from memory.  
@@ -917,7 +907,7 @@ It is an important skill to have, because when you are learning Japanese for a l
 
 **Q: So, what do I need to do today?**
 
-1. Anki. Your Core deck and the RRTK deck.  
+1. Anki. Your Kaishi 1.5k deck and the RRTK deck.  
 2. Grammar. Watch 3 Cure Dolly videos.
 3. Immersion.  
 
@@ -1207,7 +1197,7 @@ Some you might not even be able to do until months or years down the line!
 Nevertheless, I highly recommend you do them.  
 
 - Finish the entirety of Yotsubato volume 1
-- Finish the Core deck   
+- Finish the Kaishi 1.5k deck   
 - Finish the RRTK450 deck  
 - Do the [Kanji Phonetics](/kanjiphonetics) deck.  
 - Finish Cure Dolly's grammar guide  
@@ -1215,7 +1205,7 @@ Nevertheless, I highly recommend you do them.
 - Start studying Japanese pronunciation and pitch accent with [this guide](https://docs.google.com/document/d/1ReBf08JFK4n0PXdOxThAfWuiK9UWVZEWWzeKSECWTQo)
 - Start reading longer texts such as visual novels. Participate in TheMoeWay Discord's VN club to hang out with other people doing the same.  
 - Train your ability to recognize and read Japanese numbers, with this resource: [Practice Japanese Numbers](https://langpractice.com/japanese/).   
-- Start a "mining" Anki deck sometime after you finish the Core deck.  
+- Start a "mining" Anki deck sometime after you finish the Kaishi 1.5k deck.  
 - Finish a visual novel in under 6 months after starting it.   
 - Try using a monolingual dictionary after you finish a visual novel.  
 - Increase your immersion hours.  

--- a/docs/yomichan.md
+++ b/docs/yomichan.md
@@ -130,7 +130,7 @@ Tap on a word to look it up. In the case that it is not working, you may need to
 
 ## Anki Setup
 
-See [AnimeCards Site](https://animecards.site/)
+See [kuri's website](https://donkuri.github.io/learn-japanese/setup/#anki-setup).
 
 ## Offline audio server (+ More audios than default)  
 


### PR DESCRIPTION
This commit mostly takes out Tango and Core references and replaces them with Kaishi 1.5k references. It also changes the setup website from animecards to donkuri.github.io/learn-japanese/setup since animecards is currently outdated.