### PR TITLE
Adding whitespace to fix MD rendering for recommended dictionaries on the Yomichan/Yomitan guide

### DIFF
--- a/docs/yomichan.md
+++ b/docs/yomichan.md
@@ -23,7 +23,7 @@ I recommend you install the following dictionaries:
 	- `Bilingual/[Bilingual] Jitendex (Recommended).zip`  
 	- `Bilingual/[Bilingual] 新和英.zip`  
 	- `Kanji/[Kanji] KANJIDIC (English).zip`  
-	- `Grammar/Dictionary of Japanese Grammar.zip` 
+	- `Grammar/Dictionary of Japanese Grammar.zip`  
 	- `Pitch Accent/アクセント辞典v2 (Recommended).zip`
 
 ## Installing dictionaries and basic usage


### PR DESCRIPTION
I was introducing someone to the Yomichan set up page in regard to finding a pitch accent dictionary, and it turns out that he actually overlooked the recommended pitch accent dictionary due to an error in the MD rendering because of a missing whitespace. I thought I'd just go ahead and fix that as it literally takes two seconds. Thanks!