### PR TITLE
update IOS VN instructions to reflect PPSSPP being on appstore

### DIFF
--- a/docs/vn-ios.md
+++ b/docs/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/de/vn-ios.md
+++ b/multilingual_docs/de/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/es/vn-ios.md
+++ b/multilingual_docs/es/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/fr/vn-ios.md
+++ b/multilingual_docs/fr/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/id/vn-ios.md
+++ b/multilingual_docs/id/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/it/vn-ios.md
+++ b/multilingual_docs/it/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/pt-BR/vn-ios.md
+++ b/multilingual_docs/pt-BR/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/ru/vn-ios.md
+++ b/multilingual_docs/ru/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 

--- a/multilingual_docs/viet/vn-ios.md
+++ b/multilingual_docs/viet/vn-ios.md
@@ -8,10 +8,9 @@ There are a couple of native iOS "visual novels" but these are usually spin offs
 
 While there *are* in fact native iOS "visual novels", these are usually gacha trash, and nobody wants to play them. That's why I feel emulating PSP visual novels is a better idea, just because the games on a PSP console are just going to be *so* much higher quality than games made for phones.
 
-It is a little more tricky to get PPSSPP working on iOS without a jailbreak, but it is definitely possible.  
+Getting PPSSPP on iOS used to require sideloading like Kirikiroid2 does, but it can now just be found on the Appstore. 
 You will need:  
-[AltStore](https://altstore.io/) - check the [FAQ](https://altstore.io/faq/) on the website for instructions  
-[PPSSPP IPA](https://www.ppsspp.org/downloads.html)  
+[PPSSPP from the App Store](https://apps.apple.com/us/app/ppsspp-psp-emulator/id6496972903)
 
 ## Non-jailbreak: Kirikiroid2  
 


### PR DESCRIPTION
Apple has finally allowed emulators into the appstore which is why this change has happened. 
I futzed around for a while before realizing it had been added. Thought I'd make it a little easier for others.

note that I changed the multilingual because the file seemed to be identical, so may as well keep them up to date
even if in the wrong language.