### PR TITLE
Update Anki settings description

### DIFF
--- a/docs/routine.md
+++ b/docs/routine.md
@@ -265,9 +265,7 @@ When you first open Anki, the first thing you'll see is the "interface language 
 
 Go into **Tools** on the top bar, and click **Preferences (Ctrl+P)**.  
 
-In this window, click on the **Scheduling** tab, and check (✓) the option "*V3 Scheduler*".  
-
-And change the **Learn ahead limit** to `900`.  
+In this window, click on the **Review** tab and change the **Learn ahead limit** to `900`.  
 
 Now click Close.  
 


### PR DESCRIPTION
As of Anki/AnkiMobile 23.10, and AnkiDroid 2.17, the v3 scheduler is the [default and only option](https://faqs.ankiweb.net/the-2021-scheduler.html). Seems the tab was also renamed, this change reflects that.

<img width="850" alt="Screenshot 2024-12-21 at 16 39 55" src="https://github.com/user-attachments/assets/c4d86af7-3388-4c0e-9c90-57444a311e62" />

Thanks for the wonderful guide! ❤️ 