### PR TITLE
Add Pokelingo (daily Pokédex reading game, official translations only)

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -23,6 +23,7 @@
 
 ### Vocabulary
 - **[※ Kaishi 1.5k](https://ankiweb.net/shared/info/1196762551)** - The basic vocabulary deck the guide suggests to learn Japanese. You can also find it [here](https://github.com/donkuri/Kaishi/releases) (click on the `.apkg` file).  
+- [Pokelingo](https://pokelingo.io) - A daily Pokédex-entry reading game. You read a randomly selected entry in Japanese (or one of 8 other languages) and guess the Pokémon in 6 tries. Full National Dex coverage. **All Pokédex text and name data comes from the official Pokémon games. Nothing is AI-translated, machine-translated, or LLM-generated.** Useful for short daily native reading practice; entries average ~80 characters in Japanese. Free, no login.
 
 #### Legacy vocab decks:
 These are not recommended anymore.  


### PR DESCRIPTION
hey shoui

submitting my own site for the immersion or vocab section, full disclosure. been using it as a daily reading warmup while replaying SV in jp and figured it might fit here.

pokelingo.io: random pokédex entry in your target language, guess the pokémon in 5 tries. full national dex, 9 official localisations (ja en de es fr it ko zh-Hans zh-Hant).

worth saying upfront since the community rightly cares about this: every single pokédex entry on the site is the official translation from the actual game. nothing is AI translated, nothing is ChatGPT generated, nothing is machine-translated rewording. the entries come from rom dumps going back to gen 1. same for the name dataset across all 9 languages. it's official Game Freak / Nintendo text or it doesn't ship.

reasoning for adding it: pokédex entries are unusually good short native text. ~80 ja characters on average, biology and behaviour vocabulary that's genuinely hard to source elsewhere (生息地, 進化する, the species-specific motion verbs). reading one a day is ~30 seconds and the format gets you back daily without nagging.

no login, no email gate, no AI features anywhere on the site. free.

happy to adjust placement, wording, or pull it entirely if you don't think it fits. if you'd rather i open this as a discussion first rather than a PR just let me know.

ben