### PR TITLE
Add EZFurigana to resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -214,6 +214,7 @@ Note: visual novels on consoles do not have any NSFW content.
 - [Remove non-Japanese videos from YouTube](https://www.reddit.com/r/ajatt/comments/1ozfztt/no_more_separate_accounts_needed_for_youtube/)
 ### Ebooks
 - **[※ ッツ Ebook Reader](https://reader.ttsu.app/)** - Japanese book reader that supports EPUB and HTMLZ. Text is displayed in 縦書き (vertical text) by default. This is one of the best options for an authentic experience reading Japanese books.
+- [EZFurigana](https://www.ezfurigana.com/) - Read Japanese text, E-books, PDFs and web pages with furigana, word lookup, and Anki export. Useful for preparing study materials and mining from longer texts.
 #### Android apps
 - **[※ Hoshi Reader Android](https://github.com/HuangAntimony/Hoshi-Reader-Android)** - Android port of the beautiful iOS Hoshi Reader, has first-class support for 縦書き and Yomitan dictionaries, and many other awesome features. 
 - [Microsoft Edge Canary](https://play.google.com/store/apps/details?id=com.microsoft.emmx.canary&hl=en) - Fastest browser on Android for Yomitan. Great paired with Ankiconnect Android. 


### PR DESCRIPTION
Adds EZFurigana to the resources list.

EZFurigana is a Japanese reading tool for text, PDFs, EPUBs, subtitles, and web pages. It supports furigana, word lookup, and Anki export, so I added it near the reading/e-book tools where it may be useful for reading and sentence mining longer materials.

I kept the description short and neutral to match the existing resources page style.