### PR TITLE
Set up Nix flake and development environment, update README

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 venv/
 multilingual_docs
+.direnv/
+# `nix build` output folder
+result

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
-[https://learnjapanese.moe](https://learnjapanese.moe)
+<p align="center">
+  <img alt="TheMoeWay" src="docs/img/welcome.png" />
+</p>
 
-# Repository for learnjapanese.moe (TheMoeWay)  
+# Repository for [learnjapanese.moe](https://learnjapanese.moe) (TheMoeWay)
 
 Made with Material for Mkdocs
 
-# Running  
+# Running
+
+**Nix/NixOS:**
+
+```sh
+git clone https://github.com/shoui520/shoui520.github.io.git && cd shoui520.github.io/
+nix develop
+mkdocs serve
 ```
-sudo apt install git python3 python3-venv 
+
+**Debian:**
+
+```sh
+sudo apt install git python3 python3-venv
 git clone https://github.com/shoui520/shoui520.github.io.git && cd shoui520.github.io/
 python3 -m venv venv
 source venv/bin/activate
 pip3 install mkdocs-material mkdocs-open-in-new-tab click<8.3
 mkdocs serve
 ```
-
-
-
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,13 @@
       packages.${system}.default = pkgs.stdenv.mkDerivation {
         name = "themoeway";
 
+        meta = with pkgs.lib; {
+          description = "learnjapanese.moe (TheMoeWay) MkDocs site";
+          homepage = "https://learnjapanese.moe";
+          license = licenses.gpl3Only;
+          platforms = platforms.all;
+        };
+
         src = ./.;
 
         nativeBuildInputs = [ pythonEnv ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "Repository for learnjapanese.moe (TheMoeWay)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      mkdocs-open-in-new-tab = with pkgs.python3Packages; buildPythonPackage rec {
+        pname = "mkdocs-open-in-new-tab";
+        version = "1.0.8";
+        pyproject = true;
+
+        src = pkgs.fetchPypi {
+          pname = "mkdocs_open_in_new_tab";
+          inherit version;
+          hash = "sha256-Pg2tCMyZOLCxMJe+jgqkNZGd4e6y0aZI5mtd7o1X4Eg=";
+        };
+
+        postPatch = ''
+          echo "mkdocs" > requirements.txt
+          touch devdeps.txt
+        '';
+
+        build-system = [ setuptools ];
+        dependencies = [ mkdocs ];
+        pythonImportsCheck = [ "open_in_new_tab" ];
+      };
+
+      pythonEnv = pkgs.python3.withPackages (ps: [
+        ps.mkdocs-material
+        mkdocs-open-in-new-tab
+      ]);
+    in {
+      packages.${system}.default = pkgs.stdenv.mkDerivation {
+        name = "themoeway";
+
+        src = ./.;
+
+        nativeBuildInputs = [ pythonEnv ];
+
+        installPhase = ''
+          runHook preInstall
+          mkdocs build --strict --site-dir "$out"
+          runHook postInstall
+        '';
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        inputsFrom = [ self.packages.${system}.default ];
+      };
+    };
+}


### PR DESCRIPTION
Set up a [Nix](https://nixos.org) flake to make development environment setup easier with Nix/NixOS. It's reproducible, so all you have to do is run `nix develop` and all the Python dependencies will be available and you can just run `mkdocs serve`. To build the site, run `nix build`. Everything is locked to the versions in flake.lock, so everyone who activates the development environment will get the exact same versions of everything. `.envrc` gets it working with direnv.

I've also updated the setup instructions in the README with separate Debian and Nix instructions. (I also added the welcome image to the top of the README while I was there so it's more inviting/matches the front page of the site, hope you don't mind.)