### PR TITLE
Dynamic image inversion based on site theme

### DIFF
--- a/docs/font.md
+++ b/docs/font.md
@@ -1,6 +1,6 @@
 # Are you using the right font? 
 
-![Chinese vs Japanese font](img/font1.png)
+![Chinese vs Japanese font](img/font1.png){: .invertable-light }
 
 By default, your computer / phone will display kanji in a Chinese font. Japanese kanji look slightly different, and it can be damaging if you learn the Chinese appearance of kanji rather than the Japanese ones.  
 
@@ -9,13 +9,13 @@ By default, your computer / phone will display kanji in a Chinese font. Japanese
 The one character that looks strikingly different between Japanese and Chinese fonts is [直](https://jisho.org/search/%E7%9B%B4%20%23kanji) which is used in the word [直す](https://jpdb.io/search?q=%E7%9B%B4%E3%81%99) (*naosu*) which means *cure, heal, fix*.  
 
 <figure>
-  <img src="/img/font2.png" width="300" />
+  <img src="/img/font2.png" width="300" class="invertable-light" />
   <figcaption>Naosu in a Chinese font (DengXian)</figcaption>
 </figure>
 
 
 <figure>
-  <img src="/img/font3.png" width="300" />
+  <img src="/img/font3.png" width="300" class="invertable-light" />
   <figcaption>Naosu in a Japanese font (IPAex Gothic)</figcaption>
 </figure>
 
@@ -102,16 +102,18 @@ To counteract this, do the following:
 	They are there to separate the language values in that sentence, take care not to carelessly remove one.
 
 Before:
-![Firefox settings 1](img/font10.png)
+
+![Firefox settings 1](img/font10.png){: .invertable-dark .bg }
 
 After:
-![Firefox settings 2](img/font11.png)
+
+![Firefox settings 2](img/font11.png){: .invertable-dark .bg }
 
 ## Android
 
 Just add Japanese (it looks like this: 日本語) as a secondary language, it won't change your display language unless you move it to the top.  
 
-![Android settings](img/font9.jpg)
+![Android settings](img/font9.jpg){: .invertable-light .bg }
 
 ## iOS
 
@@ -122,7 +124,7 @@ Adding the Japanese keyboard (kana or romaji whatever works) should do the trick
 I think Chinese fonts on Anki cards looks the worst because kana will be sans-serif and kanji will be serif AND out of proportion AND Chinese so it looks all out of place.
 
 <figure>
-  <img src="/img/font4.png" width="900" />
+  <img src="/img/font4.png" width="900" class="invertable-light bg bw" />
   <figcaption>Oh god. Unironically a lot of people's cards look like this.</figcaption>
 </figure>
 
@@ -172,12 +174,12 @@ Now in Anki click "Add" then click on "Cards" and then "Styling" and modify your
 Preview:
 
 <figure>
-  <img src="/img/font5.png" width="900" />
+  <img src="/img/font5.png" width="900" class="invertable-light bg" />
   <figcaption>With a full Japanese definition.</figcaption>
 </figure>
 
 <figure>
-  <img src="/img/font6.png" width="900" />
+  <img src="/img/font6.png" width="900" class="invertable-light bg" />
   <figcaption>With a bilingual definition.</figcaption>
 </figure>
 
@@ -216,7 +218,7 @@ Using Popup CSS...
 
 
 <figure>
-  <img src="/img/font7.png" width="900" />
+  <img src="/img/font7.png" width="900" class="invertable-light bg" />
   <figcaption>Japanese to Japanese defintion with IPAexゴシック font.</figcaption>
 </figure>
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -114,7 +114,7 @@ The learning process for the beginner consists of:
 ## 2.2 Hiragana and Katakana  
 
 <figure>
-  <img src="/img/kana3.png" style="display: block; margin: 0 auto;" / alt="HIRAGANA AND KATAKANA IN SCRIPTS">
+  <img src="/img/kana3.png" class="invertable-light" style="display: block; margin: 0 auto;" / alt="HIRAGANA AND KATAKANA IN SCRIPTS">
   <figcaption>"Hiragana" and "Katakana" written in their scripts respectively.</figcaption>
 </figure> 
 
@@ -258,7 +258,7 @@ Kanji study methods have been a matter of debate for as long as learning Japanes
 
 While they may look like random shapes, kanji are actually formed from common components. Take for example the kanji **萌**, that is being used as the icon for this website. It is actually made up from 3 common kanji components that are used in lots of other kanji as well. 
 
-![Kanji](img/kanji.png)   
+![Kanji](img/kanji.png){: .invertable-light}
 
 While optional, learners that are struggling to tell apart different kanji may want to try studying kanji by their components in isolation. An additional *Anki deck* (explained in the next section) can be used to do this. You can find the deck [here.](https://mega.nz/file/2SJiWC4b#hL98qtC_hiLlQDg0LqVJoqD2-5ywT2Nwd4kjROY_KwQ)  
 
@@ -271,7 +271,7 @@ Anki is a flashcard program designed to help you remember large amounts of infor
 
 Visit the [Anki download page](https://apps.ankiweb.net/), and download the version of Anki for your system and install it. 
 <figure>
-  <img src="/img/ankidownload.png" / alt="Anki Download Page">
+  <img src="/img/ankidownload.png" class="invertable-light bg" / alt="Anki Download Page">
   <figcaption>Download the one for your system.</figcaption>
 </figure>  
 
@@ -295,7 +295,7 @@ Please note that while *Kaishi 1.5k* includes sentences, it is only designed to 
 
 When seeing an unfamiliar Anki card for the first time, the general rule of thumb is to click *Show Answer* so you can see what's on the back of the card.   
 <figure>
-  <img src="/img/ankikaishi.png" / alt="Anki Kaishi Deck">
+  <img src="/img/ankikaishi.png" class="invertable-light bg" / alt="Anki Kaishi Deck">
   <figcaption>The pieces of information you need to memorise.</figcaption>
 </figure>  
 Once you have had a good look, press *Again* (this is short for try again). You will be on the next card, do the same thing as it is also a card you are seeing for the first time.  

--- a/docs/ime.md
+++ b/docs/ime.md
@@ -54,7 +54,7 @@ You can switch between these two by either:
 Windows remembers what input mode you were in, **per-app**. It is not a system-wide setting.   
 The default mode is Direct Input (*A* icon), so you will most likely be using ++alt++++grave++ whenever you want to type in Japanese.  
 ??? info "An infamous IME quirk"
-	![ime in top left corner](img/ime1.png)  
+	![ime in top left corner](img/ime1.png){: .invertable-light }
 	Most modern applications will ignore the IME if a textbox is not in focus, but older Windows programs (such as Computer Management) and Java applications (such as Minecraft) can activate the IME in the "あ” mode, even if a textbox is not in focus.  
 	You will see the IME appear in the top-left corner of your screen, like shown in the picture above. You can try this out by opening Computer Management, enabling the あ mode with ++alt++++grave++, and start typing.  
 	For this reason, it is good practice to stay in the *A* mode, or ++win++++space++ to the English keyboard if it gets in your way.  

--- a/docs/kanjiphonetics.md
+++ b/docs/kanjiphonetics.md
@@ -9,9 +9,11 @@ If I told you 長 is read ちょう (chou), how would 帳, 張 and 脹 be read?
 
 ## The Usagi Chan Kanji Phonetics Deck  
 
-![gi](img/kanji_phonetics.png)  
-![kou](img/kanji_phonetics2.png)  
-![rin](img/kanji_phonetics3.png)  
+![gi](img/kanji_phonetics.png){: .invertable-light .bg }
+
+![kou](img/kanji_phonetics2.png){: .invertable-light .bg }
+
+![rin](img/kanji_phonetics3.png){: .invertable-light .bg }
 
 I made an Anki deck to teach you these components.  
 

--- a/docs/mining.md
+++ b/docs/mining.md
@@ -25,7 +25,7 @@ Press ++enter++, and the actual Anki program will now be installed.
 When complete, it should say "Anki will start shortly. You can now close this window." Close the black terminal window.  
 Then, you should see a new window pop up like this:
 
-![Image](img/shouianki2.png)  
+![Image](img/shouianki2.png){: .invertable-light .bg }
 
 This sets the **display language**, for the user interface of Anki. Any language you can read is fine.  
 
@@ -43,9 +43,11 @@ Here are the add-on codes for the essential add-ons you *must* have.
 - AnkiConnect: `2055492159`
 - PassFail2: `876946123`
 
-![Image](img/shouianki3.png)  
-![Image](img/shouianki4.png) 
-![Image](img/shouianki5.png) 
+![Image](img/shouianki3.png){: .invertable-light .bg }
+
+![Image](img/shouianki4.png){: .invertable-light .bg }
+
+![Image](img/shouianki5.png){: .invertable-light .bg }
 
 After you have added all the add-ons, restart Anki by closing it out completely and reloading it.  
 
@@ -59,14 +61,14 @@ Load the deck into Anki by double clicking on the `.apkg` file. Alternatively yo
 
 Then, you should see this, import it by clicking **Import**:
 
-![Image](img/shouianki6.png)
+![Image](img/shouianki6.png){: .invertable-light .bg }
 
 After that, you can close the import window.  
 
 The deck is now imported. Now you need to adjust the *deck settings*.   
 
 Once you have a deck imported, click on the cog/gear icon then click "Options"
-![Image](img/shouianki7.png) 
+![Image](img/shouianki7.png){: .invertable-light .bg }
 
 Adjust the settings as follows:
 
@@ -88,7 +90,7 @@ Then:
 1. Download Lapis [here](https://github.com/donkuri/lapis/releases/download/v1.6.0/Lapis.apkg). You should get a .apkg file.  
 2. Import it into Anki, then after you import that apkg, delete the "Lapis" deck it leaves behind. We only need the note type.  
 3. In Anki, click "Create Deck" on the bottom. Give your deck a name (e.g. `Mining` and press OK)  
-3. Open the Yomitan settings by clicking the Yomitan icon ![yomitan-icon](img/yomitan-icon.png) in your browser toolbar, then the ![cog](img/yomitan-cog.png) cog icon.  
+3. Open the Yomitan settings by clicking the Yomitan icon ![yomitan-icon](img/yomitan-icon.png) in your browser toolbar, then the ![cog](img/yomitan-cog.png){: .invertable-light } cog icon.
 4. Click on "**Anki**" in the sidebar, then ENABLE **Enable Anki integration**.  
 5. Then click **Configure Anki flashcards…**
 6. Change "Deck" to the name of your deck you just created (e.g. `Mining`). Change the "Model" to `Lapis`.  
@@ -133,11 +135,11 @@ This is easy!
 
 All you need to do is hold ++shift++ over a word to show Yomitan, then press the green + button to add the card.  
 
-![Mining a card](img/mining1.png)  
+![Mining a card](img/mining1.png){: .invertable-light .bg }
 
 Here's the end result:
 
-![Mined card](img/mining2.png)  
+![Mined card](img/mining2.png){: .invertable-light .bg }
 
 That card is now in my Anki deck, ready to be learned.  
 

--- a/docs/mobile-reading.md
+++ b/docs/mobile-reading.md
@@ -16,7 +16,7 @@ Download Hoshi Reader [here](https://github.com/HuangAntimony/Hoshi-Reader-Andro
 2. Allow the permission for the file manager app to install unknown apps if prompted.
 3. Tap "Install" once permission is granted.  
 
-![img](img/hoshireader_android_1.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }  
+![img](img/hoshireader_android_1.jpg){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
 
 Open the app and you will see the "Import EPUB" button, this is how you'll import a book into Hoshi Reader.
 
@@ -25,11 +25,15 @@ This will open the file picker, select an EPUB file to import your book.
 By default your books will appear as "Unshelved". The folder icon in the top-right is how you can manage your *Shelves*. This is useful for categorizing your books (plan to read, high priority, low priority, dropped, on hold, completed etc.)  
 
 To set up the pop-up dictionary, go to *Settings* then "Dictionaries". To import from .zip, tap the + in the top-right corner. Hoshi Reader can automatically fetch the latest version of JMdict with the "Download Recommended Dictionaries" option.  
-![img](img/hoshireader_android_3.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }  
+
+![img](img/hoshireader_android_3.jpg){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+
 Start reading by tapping on your imported book in *Books*.  
 
 Tap on a word to trigger the pop-up dictionary.  
-![img](img/hoshireader_android_4.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }  
+
+![img](img/hoshireader_android_4.jpg){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+
 You can adjust the appearance of the reader by tapping the settings button in the bottom-right corner. You can also adjust the size of the dictionary popup in this menu, at the bottom.  
 ![img](img/hoshireader_android_5.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }  
 ### Anki setup
@@ -39,13 +43,16 @@ This requires [AnkiDroid](https://play.google.com/store/apps/details?id=com.ichi
 In Hoshi Reader, go to *Settings* → *Anki* → tap *Fetch* in AnkiDroid. Allow the permission when prompted.  
 
 Then, choose the Anki deck.  
-![img](img/hoshireader_android_6.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }  
+
+![img](img/hoshireader_android_6.jpg){: .invertable-light .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+
 The card type "Model" will automatically be configured for Lapis, which is the recommended card type. The fields will also be automatically configured. For most people, the Anki setup is complete at this point.  
 
 
-You can then add Anki cards by opening a book, tapping a word to look it up then pressing the **+** button in the dictionary pop-up  
+You can then add Anki cards by opening a book, tapping a word to look it up then pressing the **+** button in the dictionary pop-up:
 
-![img](img/hoshireader_android_7.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }  
+![img](img/hoshireader_android_7.jpg){: .invertable-light .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+
 ### Local Audio
 
 Note: the local audio database uses 5.79GB of space on your device. Please ensure your device has sufficient space to not be out of space when the local audio database is imported to your device.
@@ -56,7 +63,9 @@ Download: [android.db](https://drive.google.com/file/d/1Fn11_nN04zM89yKFYBWVTi0X
 Setting up local audio is easy. You just need to import the android.db file. 
 
 Set it up: *Settings* → *Advanced* → *Audio* → Local Audio: Enable → tap "Import" and pick the `android.db` file.  
-![img](img/hoshireader_android_8.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }  
+
+![img](img/hoshireader_android_8.jpg){: .invertable-light .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+
 Hoshi Reader will automatically add the *Local* source and prefer it over the default source(s).  
 
 You are done!  
@@ -74,7 +83,7 @@ Additionally you can directly share books to Hoshi Reader when downloading books
 
 Hoshi Reader does not include any dictionaries out of the box. Navigate to *Settings* → *Dictionaries* to import your own Yomitan dictionaries or download a set of recommended dictionaries (JMdict, JMnedict, Jiten) by pressing on the button. You can reorder dictionaries by dragging and delete dictionaries by swiping left.
 
-![img](img/hoshireader_ios_3.png){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+![img](img/hoshireader_ios_3.png){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
 
 Open a book and tap on a word to look it up.
 
@@ -100,7 +109,7 @@ Untick *Include media* and press on *Export to Share Sheet*. You should be able 
 
 If you mine on any other devices, it's recommended to import a fresh backup periodically to make sure it stays in sync.
 
-![img](img/hoshireader_ios_6.png){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+![img](img/hoshireader_ios_6.png){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
 #### AnkiConnect
 
 If you don't have access to AnkiMobile, you can alternatively use Anki and [AnkiConnect](https://ankiweb.net/shared/info/2055492159) from your PC.
@@ -109,7 +118,7 @@ To set this up first of all make sure you have AnkiConnect installed in Anki. In
 
 Change the `webBindAddress` to `0.0.0.0`. Restart Anki.
 
-![img](img/hoshireader_ios_7.png){: style="max-height: 700px; width: auto; display: block; margin: 0 auto;" }
+![img](img/hoshireader_ios_7.png){: .invertable-light .bg style="max-height: 700px; width: auto; display: block; margin: 0 auto;" }
 
 You will need the local IPv4 address of your PC. To find your PC's IPv4 address you can open *Settings* → *Network & internet* → *Wi-Fi* or *Ethernet* depending on your connection on Windows, or *Settings* → *Wi-Fi* → *Details* on the connected network on macOS. Scroll down to find the IPv4 address (not the router/gateway address).
 
@@ -117,7 +126,7 @@ In Hoshi Reader navigate to *Settings* → *Advanced* → *AnkiConnect*. Tick *U
 
 Tap on *Connect*, you will be asked to allow Hoshi Reader to find devices on local networks. Tap *Allow* and tap on *Connect* again. A Windows Defender Firewall window may show up on your PC asking you to allow Anki to communicate on your local network. Press *Allow access*. If you aren't connected yet you may have to tap on *Connect* again. 
 
-![img](img/hoshireader_ios_8.png){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+![img](img/hoshireader_ios_8.png){: .invertable-light .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
 
 You can now follow the same steps to configure your deck and notetype in *Settings* → *Anki*. A backup is not needed when using AnkiConnect, duplicate checks will work out of the box. You will need to keep your PC on to mine cards.
 
@@ -133,7 +142,7 @@ Download: [android.db](https://drive.google.com/file/d/1Fn11_nN04zM89yKFYBWVTi0X
 
 Navigate to *Settings* → *Advanced* → *Audio*. Scroll down to the bottom and enable Local Audio. Tap on *Import* and choose the *android.db*. The database is copied into app storage, so you can delete the copy from your Downloads folder (don't press on the delete button in the app).
 
-![img](img/hoshireader_ios_10.png){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+![img](img/hoshireader_ios_10.png){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
 
 Hoshi Reader will automatically add the *Local* source and prefer it over the default source(s).  
 
@@ -195,13 +204,13 @@ Download the latest APK from [GitHub Releases](https://github.com/sohilsayed/chi
 
 Open *Settings* → *Dictionary* → to access all settings related to dictionaries and anki. For anki lapis is used as default card type.
 
-![img](img/chimahon1_2_3.jpg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+![img](img/chimahon1_2_3.jpg){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
 
 ### Local Manga
 
 Tap the **+** icon in *Browse* → *Sources* to add a local manga image folder or archive (e.g. `.cbz`) files for offline reading. You can also select the `.mokuro` file directly alongside your manga.
 
-![img](img/chimahon4.jpeg){: style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
+![img](img/chimahon4.jpeg){: .invertable-dark .bg style="max-height: 800px; width: auto; display: block; margin: 0 auto;" }
 
 ### Mokuro
 

--- a/docs/monolingual.md
+++ b/docs/monolingual.md
@@ -70,34 +70,37 @@ If you want guidelines on what to mine, then just mine every single word after y
 
 **I recommend doing the monolingual transition with Yomichan.**  
 
-![Image](img/monodemo1.png)
+![Image](img/monodemo1.png){: .invertable-dark }
 
 Yomichan is a browser extension that allows you to look up Japanese words on a webpage by holding ++shift++ and hovering over it. It is supported by any Chromium or Firefox based browser. You can find out how to set up Yomichan [here](/yomichan)  
 
 ### Optimizing Yomichan Settings 
 
 First you need to ensure that Advanced options is enabled.  
-![Image](img/mono1.jpg)
+
+![Image](img/mono1.jpg){: .invertable-light .bg }
 
 Second, we want to remove any and all scan delays because we will be making heavy use of this extension and wouldn't want to be slowed down by anything.  
 
-![Image](img/mono2.jpg)
+![Image](img/mono2.jpg){: .invertable-light .bg }
 
 Now we will enable scanning within pop-ups, this is very important, as we want to be able to look up any words we don't know within a **definiton.**  
-![Image](img/mono3.jpg)  
+
+![Image](img/mono3.jpg){: .invertable-light .bg }
 
 You may want to increase the size of your Yomichan pop up window because by default it is pretty small and will become a hindrance when using monolingual dictionaries. To make enough headroom to use Yomichan dictionaries comfortably we are going to edit the following settings.  
 
-![Image](img/mono4.jpg)  
+![Image](img/mono4.jpg){: .invertable-light .bg }
 
 Here's how our pop up looks now:  
-![Image](img/mono5.jpg) 
+
+![Image](img/mono5.jpg){: .invertable-dark .bg }
 
 Next, if you want, you don't need to but I recommend it, enable automatic audio playback, so we know how to pronounce a word correctly the moment we look it up. Also add the extra audio source because surprisingly it adds extra audio!  
 
 You can also add the Forvo audio source in Yomichan. See [Yomichan Setup Tutorial](/yomichan) for more info.  
 
-![Image](img/mono6.jpg)  
+![Image](img/mono6.jpg){: .invertable-light .bg }
 
 **Update December 2021:** You should also add a text replacement rule for words with kanji repetition marks, they usually do not appear in monolingual dictionaries unless you repeat the kanji itself. Example:　囂々 won't appear in most monolingual dictionaries but 囂囂 will.
 Go to Settings -> Translation -> Custom Text Replacement Patterns and add the following rule:  
@@ -187,7 +190,7 @@ Import the set of dictionaries that best suits you in [Recommended Dictionaries]
 
 ※ You can change dictionary priority so you can match the order by editing the number next to the dictionary. Higher the number = higher up in list.
 
-![Image](img/mono8.jpg)  
+![Image](img/mono8.jpg){: .invertable-light .bg }
 
 ### Why do you say use a lot of dictionaries?
 
@@ -221,7 +224,7 @@ You’re gonna be learning Japanese for a long time, so it is possible that your
 ### Yomichan Offline
 You can still use Yomichan offline. Here’s how.
 
-![Image](img/mono9.jpg)
+![Image](img/mono9.jpg){: .invertable-light .bg }
 
 That’s how.
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -46,14 +46,19 @@ I seriously recommend you read novels on this site: [Itazuraneko Old Library](ht
 Your first light novel will be extremely painful, but your second light novel won't be as painful. Expect a light novel to take a 1-3 months to finish reading when you're first starting out, it will get quicker overtime (I can finish a light novel in around 10 hours). Just read more, read a lot.  
 Reading scans or physicals like these is not recommended, because it is hard to look up words from it. 
 Note: I am not against 縦書き, (vertical text), the image below is an example of a *scan*.  
-![LN 1](img/ln1.jpg)
+
+![LN 1](img/ln1.jpg){: .invertable-light .bg }
+
 *Novel: Hibike! Euphonium*
 
 ![LN 2](img/ln2.jpg)
+
 *Novel: Nichijou no Natsuyasumi*
 
 You need to read stuff like this:
-[![LN 3](img/ln3.jpg)](img/ln3.jpg)
+
+[![LN 3](img/ln3.jpg){: .invertable-light .bg }](img/ln3.jpg){: target="_blank" }
+
 *Novel: Kimi no Na wa.*  
 *Click to enlarge*
 

--- a/docs/shouimethod.md
+++ b/docs/shouimethod.md
@@ -587,7 +587,7 @@ Now change some very important Yomitan settings:
 
 Under "Popup Behavior", ENABLE **Allow scanning popup content**. Set the **Maximum number of child popups** to `9999`  
 
-![Image](img/shouiyomitan1.png)  
+![Image](img/shouiyomitan1.png){: .invertable-light .bg }
 
 Without this, you won't be able to look up Japanese words in dictionary entries. With this enabled, the process becomes much easier, you can infinitely look up words within entries.  
 
@@ -598,13 +598,14 @@ If you find it too distracting you don't need to enable it though.
 
 Also, the default pop up size on Yomitan is stupidly tiny. Double the size here:
 
-![Image](img/shouiyomi3.png)  
+![Image](img/shouiyomi3.png){: .invertable-light .bg }
 
 Width=800, Height=500.  
 
 Lastly, TURN OFF this stupid thing:
 
-![Image](img/shouiyomi2.png)
+![Image](img/shouiyomi2.png){: .invertable-light .bg }
+
 ## Anki setup
 
 The Anki card type I used for the majority of my Japanese learning journey was the [Animecards](https://animecards.site) format, but with the front modified to include both the word and the sentence.  
@@ -625,7 +626,7 @@ Press ++enter++, and the actual Anki program will now be installed.
 When complete, it should say "Anki will start shortly. You can now close this window." Close the black terminal window.  
 Then, you should see a new window pop up like this:
 
-![Image](img/shouianki2.png)  
+![Image](img/shouianki2.png){: .invertable-light .bg }
 
 This sets the **display language**, for the user interface of Anki. Any language you can read is fine.  
 
@@ -647,9 +648,11 @@ Here are the add-on codes for all essential add-ons you *must* have.
 - Local Audio Server for Yomichan: `1045800357`
 - Advanced Browser: `874215009`  
 
-![Image](img/shouianki3.png)  
-![Image](img/shouianki4.png) 
-![Image](img/shouianki5.png) 
+![Image](img/shouianki3.png){: .invertable-light .bg }
+
+![Image](img/shouianki4.png){: .invertable-light .bg }
+
+![Image](img/shouianki5.png){: .invertable-light .bg }
 
 After you have added all the add-ons, restart Anki by closing it out completely and reloading it.  
 
@@ -663,7 +666,7 @@ Load the deck into Anki by double clicking on the `.apkg` file. Alternatively yo
 
 Then, you should see this, import it by clicking **Import**:
 
-![Image](img/shouianki6.png)
+![Image](img/shouianki6.png){: .invertable-light .bg }
 
 After that, you can close the import window.  
 
@@ -672,7 +675,8 @@ The deck is now imported. Now you need to adjust the *deck settings*. This will 
 ### Global deck settings
 
 Once you have a deck imported, click on the cog/gear icon then click "Options"
-![Image](img/shouianki7.png) 
+
+![Image](img/shouianki7.png){: .invertable-light .bg }
 
 Adjust the settings as follows:
 
@@ -684,8 +688,10 @@ Adjust the settings as follows:
 
 *The desired retention I used personally was <b>95%</b>, if you really want to copy me, use that, at your own discretion, but I think that might be too much for most people. 80%-90% is best for most. FSRS didn't exist for the majority of my JP learning journey, but I think it's marginally better than the stock Anki algorithm.  
 Additionally, you should consider reoptimizing FSRS parameters every now and then.  
-![Image](img/shouianki8.png)
-![Image](img/shouianki9.png)  
+
+![Image](img/shouianki8.png){: .invertable-light .bg }
+
+![Image](img/shouianki9.png){: .invertable-light .bg }
 
 You are now ready to learn with Kaishi, and any other deck.  
 ### Mining setup w/ Lapis (shoui method)  
@@ -703,7 +709,7 @@ Then:
 1. Download Lapis [here](https://github.com/donkuri/lapis/releases/download/v1.6.0/Lapis.apkg)
 2. Import it into Anki, then after you import that apkg, delete the deck it leaves behind. We only need the note type.  
 3. In Anki, click "Create Deck" on the bottom. Give your deck a name (e.g. `Mining` and press OK)  
-3. Open the Yomitan settings by clicking the Yomitan icon ![yomitan-icon](img/yomitan-icon.png) in your browser toolbar, then the ![cog](img/yomitan-cog.png) cog icon.  
+3. Open the Yomitan settings by clicking the Yomitan icon ![yomitan-icon](img/yomitan-icon.png) in your browser toolbar, then the ![cog](img/yomitan-cog.png){: .invertable-light } cog icon.
 4. Click on "**Anki**" in the sidebar, then ENABLE **Enable Anki integration**.  
 5. Then click **Configure Anki flashcards…**
 6. Change "Deck" to the name of your deck you just created (e.g. `Mining`). Change the "Model" to `Lapis`.  
@@ -833,7 +839,8 @@ Also, I recommend putting the local audio .tar.xz file on an SSD, not a mechanic
 
 Then, for this new `.tar` file, do the same: **RIGHT CLICK** the `.tar` > **7-Zip/NanaZip** > **Extract to %folder%** to extract all the local audios. This will take a long while.   
 
-![Image](img/shouilocalaudio5.png)  
+![Image](img/shouilocalaudio5.png){: .invertable-light .bg }
+
 After that is done, you should see a `user_files` folder. You need to move this to the correct location: here's how to do that👇 
 
 
@@ -841,19 +848,22 @@ After that is done, you should see a `user_files` folder. You need to move this 
 In Anki, navigate to `Tools` → `Add-ons`, then click on the `Local Audio Server for Yomichan`, then click `View files`.
 
 
-![Image](img/shouilocalaudio1.png)  
+![Image](img/shouilocalaudio1.png){: .invertable-light .bg }
 
 This path is `%APPDATA%\Anki2\addons21\1045800357`. You can also access it by pasting it into ++win++++r++  
 
 Find your extracted .tar folder, inside, there should be a `user_files` folder.  
 MOVE the entire "`user_files`" folder into the local audio addon folder, so it looks like this, and replaces the empty `user_files` folder already there:  
-![Image](img/shouilocalaudio4.png)  
-![Image](img/shouilocalaudio2.png) 
+
+![Image](img/shouilocalaudio4.png){: .invertable-light .bg }
+
+![Image](img/shouilocalaudio2.png){: .invertable-light .bg }
 
 You are nearly done!  
 Now you need to just regenerate the local audio database!  
 `Tools` → `Local Audio Server` → `Regenerate database`  
-![Image](img/shouilocalaudio3.png)  
+
+![Image](img/shouilocalaudio3.png){: .invertable-light .bg }
 
 <h3> LAST STEP! </h3>
 
@@ -867,13 +877,15 @@ Now you need to just regenerate the local audio database!
 
 It has to be "JSON"! Not "Custom URL" without the JSON!  
 
-![Image](img/shouilocalaudio6.png)  
+![Image](img/shouilocalaudio6.png){: .invertable-light .bg }
+
 You're done! 🎉
 
 ### Yomitan setup (Monolingual)
 Under "Popup Behavior", ENABLE **Allow scanning popup content**. Set the **Maximum number of child popups** to `9999`  
 
-![Image](img/shouiyomitan1.png)  
+![Image](img/shouiyomitan1.png){: .invertable-light .bg }
+
 My monolingual setup has evolved over the years. I can tell you what I did in the past, and what I recommend right now.  
 
 #### Backstory 
@@ -1070,9 +1082,12 @@ But I have always customized my settings. My eyes aren't very good.
 
 How it looks (vertical)  
 
-![Image](img/shouittsu_tate.png)
+![Image](img/shouittsu_tate.png){: .invertable-light .bg }
+
 How it looks (horizontal)
-![Image](img/shouittsu_yoko.png)
+
+![Image](img/shouittsu_yoko.png){: .invertable-light .bg }
+
 This is a very "shoui method" part of the setup. I am not even sure people would want to copy me on this one, but I genuinely think my setup is awesome.  
 
 I am a HUGE MS明朝 shill. Because I found that if bolded and made big enough, it looks like literal ink on my 1080p monitor. It's SO crisp. 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -29,3 +29,59 @@
     margin: .1rem auto;
     padding: 0 .8rem;
 }
+
+/* theme-aware value color inversion classes:
+ * .invertable-light    invert in dark mode (image is light mode)
+ * .invertable-dark     invert in light mode (image is dark mode)
+ * .bg                  add background color to distinguish from page background,
+ *                      will only render when .bg is alone in parent or with figcaption
+ * .bw                  when inverted, make desaturated
+ * */
+[data-md-color-scheme="slate"] .invertable-light,
+[data-md-color-scheme="default"] .invertable-dark
+{
+    --filter: invert(1) hue-rotate(180deg);
+    filter: var(--filter);
+
+    &.bw {
+	filter: var(--filter) saturate(0);
+    }
+}
+
+[data-md-color-scheme="slate"] .invertable-light {
+    mix-blend-mode: lighten;
+}
+
+[data-md-color-scheme="default"] .invertable-dark {
+    mix-blend-mode: darken;
+}
+
+/* Only draw the backdrop when .bg is alone in its parent (figcaption aside),
+ * otherwise it'd stretch across the sibling content */
+*:has(> .bg):not(:has(> :not(.bg, figcaption))) {
+    display: grid;
+    width: fit-content;
+
+    > .bg, &::before {
+        grid-area: 1 / 1;
+    }
+
+    &::before {
+        content: "";
+    }
+
+    [data-md-color-scheme="slate"] &::before {
+        /* same as --md-footer-bg-color in dark mode */
+        background: hsla(225deg, 15%, 10%, 0.87);
+    }
+
+    [data-md-color-scheme="default"] &::before {
+        /* same as --md-code-bg-color in light mode */
+        background: #f5f5f5;
+    }
+}
+
+/* don't break manual image centering */
+*:has(> .bg[style*="margin: 0 auto"]):not(:has(> :not(.bg, figcaption))) {
+    margin-inline: auto;
+}

--- a/docs/vn-linux.md
+++ b/docs/vn-linux.md
@@ -87,9 +87,12 @@ Here's how I recommend you play your VNs:
 Add a KDE window rule like this to "lock" the VirtualBox VM scaled window:
 
 Example, for 4:3
-![Image](img/vnlinux_vmwindowrule4x3.png)
+
+![Image](img/vnlinux_vmwindowrule4x3.png){: .invertable-light .bg .bw }
+
 Example, for 16:9
-![Image](img/vnlinux_vmwindowrule16x9.png)
+
+![Image](img/vnlinux_vmwindowrule16x9.png){: .invertable-light .bg .bw }
 
 ### Troubleshooting
 
@@ -228,7 +231,7 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 
 	As compatibility with games can vary with different Proton-GE versions, use Proton-GE 9.10 for the same environment as this guide was tested on. 
 
-	![Protonup-qt](img/new_vn_linux1.png)
+	![Protonup-qt](img/new_vn_linux1.png){: .invertable-light .bg }
 
 	### Install / Run the Visual Novel
 	What you need to do in Lutris now depends on whether the VN is already installed or not.  
@@ -248,15 +251,16 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 		cdemu load 0 /path/to/disc_image.mds
 		```
 		The disc image will now be loaded into a virtual DVD drive. You can mount it through your desktop environment, or mount manually with `mount` e.g. `mount /dev/sr0 /media/cdrom`  
-		![Mount Image](img/new_vn_linux3.png)  
+
+		![Mount Image](img/new_vn_linux3.png){: .invertable-light .bg }
 
 		In Lutris, make sure you set the default Wine version for the Wine runner to the Proton-GE version you installed with ProtonUp-Qt.
 
-		![Lutris runners 1](img/new_vn_linux7.png)
-		![Lutris runners 2](img/new_vn_linux8.png)
+		![Lutris runners 1](img/new_vn_linux7.png){: .invertable-light }
+		![Lutris runners 2](img/new_vn_linux8.png){: .invertable-light }
 
 		Then you need to set the correct environment variables.  
-		![Lutris environment variables](img/new_vn_linux12.png)
+		![Lutris environment variables](img/new_vn_linux12.png){: .invertable-light }
 
 		| Key    | Value |
 		| -------- | ------- |
@@ -266,20 +270,20 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 
 		Now in Lutris, click the `+` in the top left corner to add a game, then in the window that pops up, choose `Install a Windows game from an executable`
 
-		![Lutris menu](img/new_vn_linux2.png)
+		![Lutris menu](img/new_vn_linux2.png){: .invertable-light }
 
 		It is recommended to use Japanese locale when running visual novels, even on Windows.  
 
-		![Lutris - set locale](img/new_vn_linux4.png)
+		![Lutris - set locale](img/new_vn_linux4.png){: .invertable-light }
 
 		Set the Wine prefix directory. This is not the path for the install files.  
 
 		**USE A BLANK PREFIX.** I suggest `~/Games/VNs`. This prefix can be used for all your other VNs as long as **the same Wine version is used**- using a different Wine version on a prefix that was made with another version can actually render the prefix unusable!  
 
-		![Lutris - wine prefix](img/new_vn_linux5.png)
+		![Lutris - wine prefix](img/new_vn_linux5.png){: .invertable-light }
 
 		Choose the setup executable for the VN's installer.
-		![Lutris - choose executable](img/new_vn_linux9.png)
+		![Lutris - choose executable](img/new_vn_linux9.png){: .invertable-light }
 
 		Proceed with the installation. I do not recommend installing DirectX from the VN installer, always say no to that. When complete, Lutris should automatically set the game executable path to the game's run executable defined in the installer info/registry. 
 
@@ -293,15 +297,15 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 
 		
 
-		![Lutris runners 1](img/new_vn_linux7.png)
+		![Lutris runners 1](img/new_vn_linux7.png){: .invertable-light .bg }
 
 		Set the Wine version to GE-Proton9-10.
 
-		![Lutris runners 2](img/new_vn_linux8.png)
+		![Lutris runners 2](img/new_vn_linux8.png){: .invertable-light .bg }
 
 		Then you need to set the correct environment variables. 
 
-		![Lutris environment variables](img/new_vn_linux12.png)
+		![Lutris environment variables](img/new_vn_linux12.png){: .invertable-light .bg }
 
 		| Key    | Value |
 		| -------- | ------- |
@@ -310,14 +314,14 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 
 		Now in Lutris, click the `+` icon in the top left corner, and choose `Add locally installed game`
 
-		![Lutris add local game](img/new_vn_linux13.png)
+		![Lutris add local game](img/new_vn_linux13.png){: .invertable-light .bg }
 
 		Set the runner to Wine. The runner settings should automatically be correct if you followed the previous steps.  
 
-		![Lutris set runner](img/new_vn_linux14.png)
+		![Lutris set runner](img/new_vn_linux14.png){: .invertable-light .bg }
 
 		Now set the path to the game executable, and set the Wine prefix. This Wine prefix has to be a blank one if using Proton-GE on a prefix for the first time. After you run one VN in that prefix using that Proton-GE version, you can share the prefix for other VNs too.
-		![Lutris set exe and prefix](img/new_vn_linux15.png)  
+		![Lutris set exe and prefix](img/new_vn_linux15.png){: .invertable-light .bg }
 
 		After that you are ready to play your VN on Linux!
 
@@ -335,7 +339,7 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 
 	I used the "Run EXE inside Wine prefix" option in Lutris to install Textractor to the prefix. For some reason, trying to install it like a new game just doesn't work for me.  
 
-	![Lutris run exe in prefix](img/new_vn_linux16.png)  
+	![Lutris run exe in prefix](img/new_vn_linux16.png){: .invertable-light .bg }
 
 	I used the "Install for all users" option when installing. 
 
@@ -395,7 +399,8 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 	/k /path/to/startup_script.bat
 	```
 	I recommend creating a folder called `scripts/` or something in the root of your Wine prefix for easy access.  
-	![Lutris run bat file](img/new_vn_linux17.png)  
+
+	![Lutris run bat file](img/new_vn_linux17.png){: .invertable-light .bg }
 
 	You will need to create a startup script for every VN you add, but this isn't complicated as it just involves editing file paths.  
 
@@ -444,6 +449,7 @@ With VirtualBox running on a single core, the VM will run slower and with higher
 	It is actually not a Wine specific error, it happens on Windows too! These games are just made that way. 
 
 	![Game not installed - Wine](img/new_vn_linux10.png)  
+
 	![Game not installed - Windows](img/new_vn_linux11.png)
 
 

--- a/docs/vn-win.md
+++ b/docs/vn-win.md
@@ -45,12 +45,12 @@ So if the game tries to read a file with Japanese characters in it, or the game'
 
 	If you have bought your game on an optical disc, please insert the disc into your DVD drive. A new volume will appear on the Explorer sidebar, click on it and run the setup to proceed.  
 
-	![Image](img/vnwin-nopiracy1.png)
+	![Image](img/vnwin-nopiracy1.png){: .invertable-light .bg }
 
 	If you bought your game as digital download, it will come in a `.zip` file, extract it with [7-Zip](https://www.7-zip.org/)  
 	In some cases there will be no need for installation, in other cases you may need to install the game by running the setup and register with the DRM.  
 
-	![Image](img/vnwin-nopiracy2.png)  
+	![Image](img/vnwin-nopiracy2.png){: .invertable-light .bg }
 
 === "Pirated"
 
@@ -74,26 +74,26 @@ So if the game tries to read a file with Japanese characters in it, or the game'
 
 	> Right click the image > Select drive letter & mount > OK
 
-	![Image](img/vnwin2.jpg)  
+	![Image](img/vnwin2.jpg){: .invertable-light .bg }
 
 	After that,
 
-	![Image](img/vnwin3.jpg)  
+	![Image](img/vnwin3.jpg){: .invertable-light .bg }
 
 	The disc image is now mounted. You should see a new volume appear on your Explorer sidebar.
 
-	![Image](img/vnwin4.jpg)  
+	![Image](img/vnwin4.jpg){: .invertable-light .bg }
 
 	!!! info ".MDS/.MDF files"
 		It is a little different if you have .MDS/.MDF files, see below.  
 
-	![Image](img/vnwin5.jpg)
+	![Image](img/vnwin5.jpg){: .invertable-light .bg }
 
 ## Step 3. Installing the VN and applying patch
 
 Click on the new volume that appeared on your sidebar and run the installer. See below for details.  
 
-![Image](img/vnwin6.jpg)  
+![Image](img/vnwin6.jpg){: .invertable-light .bg }
 
 Proceed with the installation, you may want to take note of where you installed the game. I installed Angel Beats! into `D:\Games\KEY\AngelBeats!`
 

--- a/docs/yomichan.md
+++ b/docs/yomichan.md
@@ -28,7 +28,7 @@ I recommend you install the following dictionaries:
 ## Installing dictionaries and basic usage
   
 1. Click on the ![yomitan-icon](img/yomitan-icon.png) icon in the browser toolbar.  
-2. Click on the ![cog](img/yomitan-cog.png) icon to access the settings page.  
+2. Click on the ![cog](img/yomitan-cog.png){: .invertable-light } icon to access the settings page.
 3. On the left sidebar, click on "Dictionaries" and then click on "Configure installed and enabled dictionaries…"  
 4. Click the "Import" button on the bottom.  
 5. Here's where you select the dictionaries to import. Please only import the following. 
@@ -41,14 +41,14 @@ I recommend you install the following dictionaries:
 6. Please wait for the dictionaries to import. This could take a while.
 7. Once complete, you can test Yomitan by holding down the ++shift++ key and hovering over Japanese text. Here is a sample: 日本語. It will display a pop up box displaying the definitions separated by dictionary.  
 
-![Yomichan Demo](img/yomidemo1.png) 
+![Yomichan Demo](img/yomidemo1.png){: .invertable-light .bg }
 
 Click anywhere outside of the box or press the ++esc++ key to dismiss.
 Click on an individual kanji in the headword to view kanji information (only functional with KANJIDIC installed).
 
-You can click the ![audio](img/yomichan-audio.png) button to hear the word being pronounced by a native speaker.
+You can click the ![audio](img/yomichan-audio.png){: .invertable-light } button to hear the word being pronounced by a native speaker.
 
-In your browser extensions toolbar, if you click on the Yomitan logo, then on the ![search icon](img/yomitan-search.png) icon or by using the ++alt+insert++ keyboard shortcut, you can access Yomitan Search, this is where you can use Yomitan as a standalone Japanese to English dictionary. 
+In your browser extensions toolbar, if you click on the Yomitan logo, then on the ![search icon](img/yomitan-search.png){: .invertable-light } icon or by using the ++alt+insert++ keyboard shortcut, you can access Yomitan Search, this is where you can use Yomitan as a standalone Japanese to English dictionary.
 
 Pop up box size can be edited with advanced settings enabled.  
 A full dark mode can be enabled in the settings too.  
@@ -111,6 +111,7 @@ Firefox:
 ## Bonus: Android use with Edge Canary
 
 ![Yomitan on Android](img/yomichan_android_updated.jpg)
+
 See [mobile readers](/mobile-reading).  
 
 ## Anki Setup

--- a/docs/yomicss.md
+++ b/docs/yomicss.md
@@ -52,7 +52,8 @@ With the following CSS:
 }
 ```
 The result:  
-![Yomichan CSS Demo](img/yomicss1.jpg)  
+
+![Yomichan CSS Demo](img/yomicss1.jpg){: .invertable-light .bg }
 
 This demonstrates differing font colors for kanji and kana. You may edit this to your heart's content.
 
@@ -83,6 +84,7 @@ With the following CSS:
 }
 ```  
 The result:
+
 ![Yomichan CSS Demo](img/yomicss2.jpg)  
 
 This demonstrates the changing of font for definitions to MS Mincho. Linux users may be able to use `Noto Serif CJK JP` as an alternative. 
@@ -101,6 +103,7 @@ With the following CSS:
 }
 ```  
 The result:
+
 ![Yomichan CSS Demo](img/yomicss3.jpg)  
 
 You may edit this to your heart's content.  
@@ -137,6 +140,7 @@ With the following CSS:
 ```
 
 The result:    
+
 ![Yomichan CSS Demo](img/yomicss4.jpg)   
 
 You may edit this to your heart's content.  
@@ -237,6 +241,7 @@ body {
 ```  
 
 The result:  
+
 ![Yomichan CSS Demo](img/yomicssnord.jpg)  
 
 ## Background
@@ -260,6 +265,7 @@ body {
 ```
 
 The result:
+
 ![Yomichan CSS Demo](img/yomicss5.jpg)
 
 You may edit this to your heart's content.  
@@ -310,7 +316,7 @@ With the following CSS:
 ```
 
 The result:
-![Yomichan CSS Demo](img/yomicss6.jpg)  
+![Yomichan CSS Demo](img/yomicss6.jpg){: .invertable-light }
 
 ### Removing progress bar
 
@@ -340,7 +346,8 @@ If you are using dark theme you need to have this instead:
 ```  
   
 The result:  
-![Yomichan CSS Demo](img/yomicss7.jpg) 
+
+![Yomichan CSS Demo](img/yomicss7.jpg){: .invertable-light }
 
 ### Removing Edict markers
 
@@ -356,7 +363,7 @@ You can remove it by using the CSS below:
 ```
 
 The result:  
-![Yomichan CSS Demo](img/yomicss8.jpg)
+![Yomichan CSS Demo](img/yomicss8.jpg){: .invertable-light }
 
 
 ### Light / Dark mode varying CSS


### PR DESCRIPTION
There are quite a few images on the site which are designed for light theme that don't look good in dark theme. This PR introduces four new classes to the extra CSS:

- `.invertable-light`: invert in dark mode (image is light mode)
- `.invertable-dark`: invert in light mode (image is dark mode)
- `.bg`: add background color to distinguish from page background
- `.bw`: when inverted, make desaturated

The filtering is done like this:

```CSS
mix-blend-mode: lighten; /* or darken, for .invertable-dark */
filter: invert(1) hue-rotate(180deg);
```

`hue-rotate(180deg);` corrects the hue of all of the colors in the image after inversion to ensure that colors remain looking the same and it doesn't visually look like an inverted image, so only values are inverted. `mix-blend-mode` ensures that the background color of the image isn't being drawn and the desired background color (just the page background color, or that of `.bg`) shows through instead.

<br>
<br>

(Don't mind my yomitan in a couple of the screenshots)

Before these edits, https://learnjapanese.moe/font looked like this:

<img width="448" height="493" alt="/font, before" src="https://github.com/user-attachments/assets/07f0aa29-03ab-430b-88e0-2c9bc4d7cc61" />

Now it looks like this, with light mode uneffected:

<img width="448" height="493" alt="/font, after" src="https://github.com/user-attachments/assets/600d1470-afa7-4594-a2b0-54f4d7c94324" />

<br>
<br>

https://learnjapanese.moe/guide, before:

<img width="448" height="493" alt="/guide, before" src="https://github.com/user-attachments/assets/aef602e3-2a74-4293-803d-740541173d37" />

After:

<img width="448" height="493" alt="/guide, after" src="https://github.com/user-attachments/assets/4f02a46f-a7bf-4b33-a27a-852d4a732d83" />

<br>
<br>

https://learnjapanese.moe/mobile-reading, before:

<img width="448" height="493" alt="/mobile-reading, before" src="https://github.com/user-attachments/assets/81e1b7a6-c7ab-4c96-818e-81daa1a6e708" />

After:

<img width="448" height="493" alt="/mobile-reading, after" src="https://github.com/user-attachments/assets/c19a960a-62b8-4cd1-a9e6-899b96110bff" />