### PR TITLE
resources: add Linglass CI Hub to Difficulty Analysis

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -314,6 +314,7 @@ See Applications section for an EPWING reader.
 - [Jiten.moe](https://jiten.moe/) - Inspired by JPDB.io, but more up to date and has more features. Recommended.
 - [JPDB.IO](https://jpdb.io/) - Japanese media word count and difficulty rating. Might help you in trying to pick what to read.
 - [Japanese Media Recommendations List](https://docs.google.com/spreadsheets/d/1w42HEKEu2AzZg9K7PI0ma9ICmr2qYEKQ9IF4XxFSnQU/)
+- [Linglass CI Hub](https://linglass.app/comprehensible-input/japanese) - Difficulty scores for ~8,500 videos across 75 Japanese YouTube channels, computed from each video's own subtitle track (mostly speaking pace, partly vocabulary load). Filter by level, length and pace, then watch on YouTube. Free, no account. The [method](https://linglass.app/comprehensible-input/method) and its limits are published — note that the JLPT bands it shows read about a level too hard.
 ### Context & Sentence Search
 - [Jiten.moe](https://jiten.moe/)
 - [Immersion Kit](https://www.immersionkit.com/) - Search sentences from anime, games etc. with translation. Made by Game Gengo.


### PR DESCRIPTION
`### Difficulty Analysis` currently covers anime, novels and visual novels — Jiten, JPDB and the recommendations sheet. Nothing in it covers YouTube, which is where a lot of intermediate listening practice actually happens.

This adds an index of 75 Japanese YouTube channels (~8,500 videos), where each video is scored from its own subtitle track — roughly 80% speaking pace, 20% vocabulary load. You can filter by level, length, pace, and made-for-learners vs native content, then click straight through to YouTube.

Free, no account, no paywall. The scoring method is published, including where it is weak: scores compare within a language and not across languages, and the JLPT bands currently read about a level too hard, so the score is the more reliable of the two.