### PR TITLE
fix: correct lifesyle typo and remove broken YouTube link

### DIFF
--- a/docs/routine.md
+++ b/docs/routine.md
@@ -1142,9 +1142,9 @@ Watch what interests you!
 
 This study guide (UsagiSpoon) was just making a few of the decisions for you.  
 
-**Q: What is the ideal UsagiSpoon lifesyle?**  
+**Q: What is the ideal UsagiSpoon lifestyle?**  
 
-A: [https://www.youtube.com/watch?v=r5Qxr8OGkaA](https://www.youtube.com/watch?v=r5Qxr8OGkaA)  
+A: (video unavailable — no longer public)  
 
 
 ## Day 31 and beyond: After UsagiSpoon?  


### PR DESCRIPTION
## Summary
Two small fixes in docs/routine.md:
1. **Typo fix**: `lifesyle` → `lifestyle` in the UsagiSpoon FAQ
2. **Broken link removal**: Removed YouTube link that is no longer public (video has been made private/unlisted)

## Changes
- `docs/routine.md` line 1145: `UsagiSpoon lifesyle` → `UsagiSpoon lifestyle`
- `docs/routine.md` line 1147: Removed broken YouTube link (https://www.youtube.com/watch?v=r5Qxr8OGkaA — video no longer public per issue #110)

## Testing
- Syntax check: docs/routine.md renders correctly (plain markdown)
- No new broken links introduced
- Follows existing document style