### PR TITLE
resources: add Toku Reader to iOS reading apps

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -232,6 +232,7 @@ Note: visual novels on consoles do not have any NSFW content.
 - [Manabi Reader](https://reader.manabi.io/) - One-tap Japanese word look-ups and Anki card creation support. 
 - [Immersion Reader](https://apps.apple.com/us/app/immersion-reader/id6443721334) - Japanese e-book reader with a fast dictionary look up feature. 
 - [10ten Japanese Reader](https://apps.apple.com/app/10ten-japanese-reader/id1573540634) - Similar in a way to Yomitan.  
+- [Toku Reader](https://apps.apple.com/us/app/toku-reader/id6761078304) - Tap any word in EPUBs, PDFs, web pages, podcast transcripts, or pasted text for readings, pitch accent, and meanings. Offline JMdict, SRS, and Anki export; the free plan caps daily lookups. Also on [Android](https://play.google.com/store/apps/details?id=com.darren.tokureader).
 ### Manga
 - **[※ Manatan all-in-one](https://github.com/KolbyML/Manatan)** - Easy to use all-in-one solution for reading Japanese manga with automatic OCR for seamless Yomitan lookups. Supports Desktop, iOS, and Android. [Manatan add-repo page](https://manatan-community.github.io/extensions/add-repo/)
 - [mokuro catalog](https://mokuro.moe/catalog/)  


### PR DESCRIPTION
Adds **Toku Reader** to *Immersion Environment & Mining → Ebooks → iOS apps*, next to Hoshi Reader, Shiori Reader and Manabi Reader.

**Disclosure: I'm the developer of Toku Reader.** Happy for it to be judged on the same bar as anything else on the page, and equally happy for this to be closed if it isn't a fit for the shelf.

Line added:

```
- [Toku Reader](https://apps.apple.com/us/app/toku-reader/id6761078304) - Tap any word in EPUBs, PDFs, web pages, podcast transcripts, or pasted text for readings, pitch accent, and meanings. Offline JMdict, SRS, and Anki export; the free plan caps daily lookups. Also on [Android](https://play.google.com/store/apps/details?id=com.darren.tokureader).
```

What it does, briefly:

- Tap-to-look-up over pasted text, websites, EPUB/PDF, camera OCR, podcasts (on-device transcripts) and YouTube captions.
- Furigana and pitch accent, conjugation breakdown, and the dictionary entry — from a bundled JMdict, offline, no account needed.
- Built-in SRS review, Anki export, and WaniKani integration.
- iPhone/iPad and Android. Reading is unmetered; the free plan caps daily word lookups.
- It also handles Mandarin (pinyin with tone sandhi, CC-CEDICT), which isn't relevant to this page but is worth stating plainly.

Both links checked and returning 200. One line changed, nothing else touched — CRLF line ending preserved to match the file.
